### PR TITLE
handle withdraw amounts with change, appropriate error response

### DIFF
--- a/app/source/main.py
+++ b/app/source/main.py
@@ -24,7 +24,10 @@ def main_event_loop():
                 print(response[1])
 
             if command[0] == "withdraw":
-                result, message = atm.withdraw(int(command[1]), token)
+                if float(command[1]) * 100 % 100 != 0:
+                    raise ATMException("Invalid Transaction Amount")
+
+                result, message = atm.withdraw(int(float(command[1])), token)
 
                 if result:
                     print("Amount dispensed: {}".format(command[1]))


### PR DESCRIPTION
Because we expected even dollar amounts on withdraw events, source fails to handle when user asks for change as part of amount dispensed. 

fix included checks if change has been provided as part of input and appropriately indicates error instead of crashing and burning. 